### PR TITLE
Add support for filtering control change events

### DIFF
--- a/src/Bonsai.Midi/ControlChange.cs
+++ b/src/Bonsai.Midi/ControlChange.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.ComponentModel;
+using Melanchall.DryWetMidi.Core;
+
+namespace Bonsai.Midi
+{
+    /// <summary>
+    /// Represents an operator that filters the MIDI event sequence for control change events.
+    /// </summary>
+    [Description("Filters the MIDI event sequence for control change events.")]
+    public class ControlChange : Combinator<MidiEvent, ControlChangeEvent>
+    {
+        /// <summary>
+        /// Filters an observable sequence of MIDI events and emits a notification only
+        /// when a new MIDI control change event is raised.
+        /// </summary>
+        /// <param name="source">A sequence of <see cref="MidiEvent"/> messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="ControlChangeEvent"/> messages.
+        /// </returns>
+        public override IObservable<ControlChangeEvent> Process(IObservable<MidiEvent> source)
+        {
+            return source.OfType<ControlChangeEvent>(MidiEventType.ControlChange);
+        }
+    }
+}

--- a/src/Bonsai.Midi/ObservableExtensions.cs
+++ b/src/Bonsai.Midi/ObservableExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using Melanchall.DryWetMidi.Core;
+
+namespace Bonsai.Midi
+{
+    static class ObservableExtensions
+    {
+        public static IObservable<TEvent> OfType<TEvent>(this IObservable<MidiEvent> source, MidiEventType eventType)
+            where TEvent : MidiEvent
+        {
+            return Observable.Create<TEvent>(observer =>
+            {
+                var eventObserver = Observer.Create<MidiEvent>(
+                    value =>
+                    {
+                        if (value.EventType == eventType)
+                        {
+                            observer.OnNext((TEvent)value);
+                        }
+                    },
+                    observer.OnError,
+                    observer.OnCompleted);
+                return source.SubscribeSafe(eventObserver);
+            });
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a general operator for casting MIDI events to specific event types and adds the `ControlChange` operator to filter events raised when a controller value changes.