### PR TITLE
Add operators for converting MIDI values

### DIFF
--- a/src/Bonsai.Midi/ToByte.cs
+++ b/src/Bonsai.Midi/ToByte.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Melanchall.DryWetMidi.Common;
+
+namespace Bonsai.Midi
+{
+    /// <summary>
+    /// Represents an operator that converts a sequence of 7 or 4-bit numbers to
+    /// a sequence of 8-bit unsigned integer values.
+    /// </summary>
+    [Description("Converts a sequence of 7 or 4-bit numbers to a sequence of 8-bit unsigned integer values.")]
+    public class ToByte : Transform<SevenBitNumber, byte>
+    {
+        /// <summary>
+        /// Converts all 7-bit values in an observable sequence to 8-bit
+        /// unsigned integers.
+        /// </summary>
+        /// <param name="source">A sequence of 7-bit number values.</param>
+        /// <returns>A sequence of 8-bit unsigned integers.</returns>
+        public override IObservable<byte> Process(IObservable<SevenBitNumber> source)
+        {
+            return source.Select(value => (byte)value);
+        }
+
+        /// <summary>
+        /// Converts all 4-bit values in an observable sequence to 8-bit
+        /// unsigned integers.
+        /// </summary>
+        /// <param name="source">A sequence of 4-bit number values.</param>
+        /// <returns>A sequence of 8-bit unsigned integers.</returns>
+        public IObservable<byte> Process(IObservable<FourBitNumber> source)
+        {
+            return source.Select(value => (byte)value);
+        }
+    }
+}

--- a/src/Bonsai.Midi/ToFourBitNumber.cs
+++ b/src/Bonsai.Midi/ToFourBitNumber.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Melanchall.DryWetMidi.Common;
+
+namespace Bonsai.Midi
+{
+    /// <summary>
+    /// Represents an operator that converts a sequence of 8-bit unsigned integer values
+    /// to a sequence of 4-bit numbers.
+    /// </summary>
+    [Description("Converts a sequence of 8-bit unsigned integer values to a sequence of 4-bit numbers.")]
+    public class ToFourBitNumber : Transform<byte, FourBitNumber>
+    {
+        /// <summary>
+        /// Converts all 8-bit unsigned integer values in an observable sequence
+        /// to 4-bit numbers.
+        /// </summary>
+        /// <param name="source">A sequence of 8-bit unsigned integer values.</param>
+        /// <returns>A sequence of 4-bit numbers.</returns>
+        public override IObservable<FourBitNumber> Process(IObservable<byte> source)
+        {
+            return source.Select(value => (FourBitNumber)value);
+        }
+    }
+}

--- a/src/Bonsai.Midi/ToSevenBitNumber.cs
+++ b/src/Bonsai.Midi/ToSevenBitNumber.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Melanchall.DryWetMidi.Common;
+
+namespace Bonsai.Midi
+{
+    /// <summary>
+    /// Represents an operator that converts a sequence of 8-bit unsigned integer values
+    /// to a sequence of 7-bit numbers.
+    /// </summary>
+    [Description("Converts a sequence of 8-bit unsigned integer values to a sequence of 7-bit numbers.")]
+    public class ToSevenBitNumber : Transform<byte, SevenBitNumber>
+    {
+        /// <summary>
+        /// Converts all 8-bit unsigned integer values in an observable sequence
+        /// to 7-bit numbers.
+        /// </summary>
+        /// <param name="source">A sequence of 8-bit unsigned integer values.</param>
+        /// <returns>A sequence of 7-bit numbers.</returns>
+        public override IObservable<SevenBitNumber> Process(IObservable<byte> source)
+        {
+            return source.Select(value => (SevenBitNumber)value);
+        }
+    }
+}


### PR DESCRIPTION
The MIDI protocol encodes values as either 7-bit or 4-bit numbers. This PR introduces operators for converting to and from these various representations.